### PR TITLE
Add HTTP API Documentation

### DIFF
--- a/looper/api/README.md
+++ b/looper/api/README.md
@@ -19,3 +19,11 @@ curl -X POST -H "Content-Type: application/json" -d '{"run": {}, "looper_config"
 with the project files in the same `looper/api` folder.
 
 This example sends a JSON payload with the `run` and `looper_config` parameters to the `/` endpoint.
+
+## API Documentation
+The API documentation is automatically generated and can be accessed in your web browser:
+
+Swagger UI: http://127.0.0.1:8000/docs
+ReDoc: http://127.0.0.1:8000/redoc
+
+Explore the API documentation to understand available endpoints, request parameters, and response formats.

--- a/looper/api/main.py
+++ b/looper/api/main.py
@@ -1,11 +1,13 @@
 from argparse import ArgumentParser, Namespace
 import secrets
+import io
 from typing import Dict, TypeAlias
 
 import fastapi
-from fastapi import FastAPI
 import pydantic
 import uvicorn
+
+from fastapi import FastAPI
 
 from looper.cli_pydantic import run_looper
 from looper.command_models.commands import SUPPORTED_COMMANDS, TopLevelParser
@@ -16,18 +18,21 @@ stdout_redirects.enable_proxy()
 
 JobId: TypeAlias = str
 
+
 class Job(pydantic.BaseModel):
     id: JobId = pydantic.Field(
         default_factory=lambda: secrets.token_urlsafe(4),
-        description="The unique identifier of the job"
+        description="The unique identifier of the job",
     )
     status: str = pydantic.Field(
         default="in_progress",
-        description="The current status of the job. Can be either `in_progress` or `completed`."
+        description="The current status of the job. Can be either `in_progress` or `completed`.",
     )
-    console_output: str | None = pydantic.Field(default=None,
-        description="Console output produced by `looper` while performing the requested action"
+    console_output: str | None = pydantic.Field(
+        default=None,
+        description="Console output produced by `looper` while performing the requested action",
     )
+
 
 app = FastAPI(validate_model=True)
 jobs: Dict[str, Job] = {}

--- a/looper/api/main.py
+++ b/looper/api/main.py
@@ -83,15 +83,29 @@ def create_argparse_namespace(top_level_model: TopLevelParser) -> Namespace:
             setattr(namespace, argname, command_namespace)
     return namespace
 
-@app.post("/", status_code=202)
-async def main_endpoint(top_level_model: TopLevelParser, background_tasks: fastapi.BackgroundTasks) -> Dict:
+
+@app.post(
+    "/",
+    status_code=202,
+    summary="Run Looper in Background",
+    description="Create a new job, process data with the specified "
+    "`top_level_model`, and initiate a background asynchronous task to run "
+    "looper.",
+)
+async def main_endpoint(
+    top_level_model: TopLevelParser, background_tasks: fastapi.BackgroundTasks
+) -> Dict:
     job = Job()
     jobs[job.id] = job
     background_tasks.add_task(background_async, top_level_model, job.id)
     return {"job_id": job.id}
 
 
-@app.get("/status/{job_id}")
+@app.get(
+    "/status/{job_id}",
+    summary="Get Job Status",
+    description="Retrieve the status of a job based on its unique identifier.",
+)
 async def get_status(job_id: JobId) -> Job:
     return jobs[job_id]
 

--- a/looper/api/main.py
+++ b/looper/api/main.py
@@ -87,10 +87,9 @@ def create_argparse_namespace(top_level_model: TopLevelParser) -> Namespace:
 @app.post(
     "/",
     status_code=202,
-    summary="Run Looper in Background",
-    description="Create a new job, process data with the specified "
-    "`top_level_model`, and initiate a background asynchronous task to run "
-    "looper.",
+    summary="Run Looper",
+    description="Start a `looper` command with arguments specified in "
+    "`top_level_model` in the background and return a job identifier.",
 )
 async def main_endpoint(
     top_level_model: TopLevelParser, background_tasks: fastapi.BackgroundTasks

--- a/looper/api/main.py
+++ b/looper/api/main.py
@@ -102,7 +102,7 @@ async def main_endpoint(
 
 @app.get(
     "/status/{job_id}",
-    summary="Get Job Status",
+    summary="Get job status",
     description="Retrieve the status of a job based on its unique identifier.",
 )
 async def get_status(job_id: JobId) -> Job:


### PR DESCRIPTION
### Description

This PR introduces comprehensive documentation for the HTTP API, covering the `main_endpoint` and `status` endpoints. Additionally, code formatting has been applied.

### Changes Made

1. **HTTP API Documentation:**
    - Documented the `main_endpoint` providing details on its purpose.
    - Documented the `status` endpoint for retrieving job status.

2. **Code Formatting:**
    - Applied code formatting using `black`.

### How to Test

1. Clone this branch.
2. Run the application locally (the instruction is in `api/README.md`).
3. Access the API documentation at `/docs` and `/redoc` endpoints to review the newly added documentation.